### PR TITLE
v1.2

### DIFF
--- a/ontology/ontology-annotator/solr-ontology-updateprocessor/README.md
+++ b/ontology/ontology-annotator/solr-ontology-updateprocessor/README.md
@@ -150,6 +150,8 @@ include the labels of the nodes as part of the stored data. Has no
 effect if `includeParentPaths` is set to `false`. Default: `false`
 * **parentPathsField** - the field to use to store the parent paths.
 Default: `parent_paths_t`
+* **includeDescendants** - Set to `false` to skip descendant references. Default: `true`
+* **includeChildren** - Set to `false` to skip child document references. Default: `true`
 
 
 ### Additional configuration (OWL files)

--- a/ontology/ontology-annotator/solr-ontology-updateprocessor/pom.xml
+++ b/ontology/ontology-annotator/solr-ontology-updateprocessor/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>uk.co.flax</groupId>
 	<artifactId>solr-ontology-update-processor</artifactId>
-	<version>1.0</version>
+	<version>1.2</version>
 
 	<name>Solr Ontology Update Processor</name>
 	<description>Solr update processor for adding ontology data to documents with ontology annotations.</description>

--- a/ontology/ontology-annotator/solr-ontology-updateprocessor/src/main/java/uk/co/flax/biosolr/solr/update/processor/OntologyUpdateProcessorFactory.java
+++ b/ontology/ontology-annotator/solr-ontology-updateprocessor/src/main/java/uk/co/flax/biosolr/solr/update/processor/OntologyUpdateProcessorFactory.java
@@ -176,6 +176,8 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 	private static final String PARENT_PATHS_LABEL_PARAM = "includeParentPathLabels";
 	private static final String PARENT_PATHS_FIELD_PARAM = "parentPathsField";
 
+	private static final String INCLUDE_CHILDREN_PARAM = "includeChildren";
+	private static final String INCLUDE_DESCENDANTS_PARAM = "includeDescendants";
 
 	/*
 	 * Default field values
@@ -198,11 +200,13 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 	private String labelField;
 	private String uriFieldSuffix;
 	private String labelFieldSuffix;
+	private boolean includeChildren;
 	private String childUriField;
 	private String childLabelField;
 	private String parentUriField;
 	private String parentLabelField;
 	private boolean includeIndirect;
+	private boolean includeDescendants;
 	private String descendantUriField;
 	private String descendantLabelField;
 	private String ancestorUriField;
@@ -233,6 +237,7 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 			this.labelField = params.get(LABEL_FIELD_PARAM, fieldPrefix + LABEL_FIELD_DEFAULT);
 			this.uriFieldSuffix = params.get(URI_FIELD_SUFFIX_PARAM, URI_FIELD_SUFFIX);
 			this.labelFieldSuffix = params.get(LABEL_FIELD_SUFFIX_PARAM, LABEL_FIELD_SUFFIX);
+			this.includeChildren = params.getBool(INCLUDE_CHILDREN_PARAM, true);
 			String childField = params.get(CHILD_FIELD_PARAM, fieldPrefix + CHILD_FIELD_DEFAULT);
 			this.childUriField = childField + uriFieldSuffix;
 			this.childLabelField = childField + labelFieldSuffix;
@@ -240,6 +245,7 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 			this.parentUriField = parentField + uriFieldSuffix;
 			this.parentLabelField = parentField + labelFieldSuffix;
 			this.includeIndirect = params.getBool(INCLUDE_INDIRECT_PARAM, true);
+			this.includeDescendants = params.getBool(INCLUDE_DESCENDANTS_PARAM, true);
 			String descendentField = params.get(DESCENDANT_FIELD_PARAM, fieldPrefix + DESCENDANT_FIELD_DEFAULT);
 			this.descendantUriField = descendentField + uriFieldSuffix;
 			this.descendantLabelField = descendentField + labelFieldSuffix;
@@ -391,6 +397,14 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 		return parentPathsField;
 	}
 
+	public boolean isIncludeChildren() {
+		return includeChildren;
+	}
+
+	public boolean isIncludeDescendants() {
+		return includeDescendants;
+	}
+
 	public synchronized OntologyHelper initialiseHelper() throws OntologyHelperException {
 		if (helper == null) {
 			helper = helperFactory.buildOntologyHelper();
@@ -476,15 +490,19 @@ public class OntologyUpdateProcessorFactory extends UpdateRequestProcessorFactor
 			}
 
 			// Add child and parent URIs and labels
-			doc.addField(getChildUriField(), data.getChildIris());
-			doc.addField(getChildLabelField(), data.getChildLabels());
+			if (isIncludeChildren()) {
+				doc.addField(getChildUriField(), data.getChildIris());
+				doc.addField(getChildLabelField(), data.getChildLabels());
+			}
 			doc.addField(getParentUriField(), data.getParentIris());
 			doc.addField(getParentLabelField(), data.getParentLabels());
 
 			if (isIncludeIndirect()) {
 				// Add descendant and ancestor URIs and labels
-				doc.addField(getDescendantUriField(), data.getDescendantIris());
-				doc.addField(getDescendantLabelField(), data.getDescendantLabels());
+				if (isIncludeDescendants()) {
+					doc.addField(getDescendantUriField(), data.getDescendantIris());
+					doc.addField(getDescendantLabelField(), data.getDescendantLabels());
+				}
 				doc.addField(getAncestorUriField(), data.getAncestorIris());
 				doc.addField(getAncestorLabelField(), data.getAncestorLabels());
 			}

--- a/ontology/ontology-annotator/solr-ontology-updateprocessor/src/test/java/uk/co/flax/biosolr/solr/update/processor/OntologyUpdateProcessorFactoryTest.java
+++ b/ontology/ontology-annotator/solr-ontology-updateprocessor/src/test/java/uk/co/flax/biosolr/solr/update/processor/OntologyUpdateProcessorFactoryTest.java
@@ -39,7 +39,7 @@ public abstract class OntologyUpdateProcessorFactoryTest extends SolrTestCaseJ4 
 
 	static final String TEST_IRI = "http://www.ebi.ac.uk/efo/EFO_0000001";
 	static final String ONTOLOGY_UPDATE_CHAIN = "ontology";
-	static final String TEST_CHILD_IRI = "http://www.ifomis.org/bfo/1.1/snap#MaterialEntity";
+	static final String TEST_CHILD_IRI = "http://purl.obolibrary.org/obo/IAO_0000030";
 
 	static void checkNumDocs(int n) {
 		SolrQueryRequest req = req();
@@ -80,7 +80,7 @@ public abstract class OntologyUpdateProcessorFactoryTest extends SolrTestCaseJ4 
 		SolrQueryRequest req = req("id:1");
 		assertQ("Could not find child", req, "//result[@numFound=1]",
 				"//arr[@name='annotation_uri_child_uris_s']/str[1][.='" + TEST_CHILD_IRI + "']",
-		"//arr[@name='annotation_uri_child_labels_t']/str[1][.='material entity']");
+		"//arr[@name='annotation_uri_child_labels_t']/str[1][.='information entity']");
 	}
 
 	@Test

--- a/ontology/ontology-annotator/solr-ontology-updateprocessor/src/test/resources/ontologyUpdate/owl/test.owl
+++ b/ontology/ontology-annotator/solr-ontology-updateprocessor/src/test/resources/ontologyUpdate/owl/test.owl
@@ -1,66 +1,58 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rdf:RDF [
-    <!ENTITY terms "http://purl.org/dc/terms/" >
-    <!ENTITY efo "http://www.ebi.ac.uk/efo/" >
-]>
-<rdf:RDF xmlns="http://www.ebi.ac.uk/efo" xml:base="http://www.ebi.ac.uk/efo" 
-	xmlns:ro="http://www.obofoundry.org/ro/ro.owl#" 
-	xmlns:efo="http://www.ebi.ac.uk/efo/" 
-	xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#" 
-	xmlns:terms="http://purl.org/dc/terms/" 
-	xmlns:uberon="http://purl.obolibrary.org/obo/uberon#" 
-	xmlns:ORDO="http://www.orpha.net/ORDO/" 
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
-	xmlns:bto="http://purl.obolibrary.org/obo/bto#" 
-	xmlns:rdfns="http://www.orphanet.org/rdfns#" 
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-	xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#" 
-	xmlns:dc="http://purl.org/dc/elements/1.1/" 
-	xmlns:PATO="http://purl.org/obo/owl/PATO#" 
-	xmlns:phenoscape-anatomy="http://purl.obolibrary.org/obo/uberon/phenoscape-anatomy#" 
-	xmlns:patterns="http://www.co-ode.org/patterns#" 
-	xmlns:foaf="http://xmlns.com/foaf/0.1/" 
-	xmlns:resource="http://semanticscience.org/resource/" 
-	xmlns:ncbitaxon="http://purl.obolibrary.org/obo/ncbitaxon#" 
-	xmlns:obo="http://purl.obolibrary.org/obo/" 
-	xmlns:obo2="http://purl.obolibrary.org/obo#" 
-	xmlns:owl="http://www.w3.org/2002/07/owl#" 
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#" 
-	xmlns:core="http://purl.obolibrary.org/obo/uberon/core#" 
-	xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#" 
-	xmlns:doap="http://usefulinc.com/ns/doap#" 
-	xmlns:go="http://purl.obolibrary.org/obo/go#" 
-	xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.ebi.ac.uk/efo/efo.owl#"
+     xml:base="http://www.ebi.ac.uk/efo/efo.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:efo="http://www.ebi.ac.uk/efo/"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:core="http://purl.obolibrary.org/obo/uberon/core#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:obo2="http://purl.obolibrary.org/obo#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:chebi="http://purl.obolibrary.org/obo/chebi/"
+     xmlns:core1="http://purl.obolibrary.org/obo/core#"
+     xmlns:mondo="http://purl.obolibrary.org/obo/mondo#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:chebi3="http://purl.obolibrary.org/obo/chebi#"
+     xmlns:chebi4="http://purl.obolibrary.org/obo/chebi#2"
+     xmlns:chebi5="http://purl.obolibrary.org/obo/chebi#3"
+     xmlns:chebi6="http://purl.obolibrary.org/obo/chebi#1"
+     xmlns:elements="http://www.geneontology.org/formats/oboInOwl#http://purl.org/dc/elements/1.1/"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:patterns="http://www.co-ode.org/patterns#"
+     xmlns:ncbitaxon="http://purl.obolibrary.org/obo/ncbitaxon#">
 	
-	<owl:Class rdf:about="http://www.ebi.ac.uk/efo/EFO_0000001">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">experimental factor</rdfs:label>
-        <owl:disjointWith rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
+    <owl:Class rdf:about="http://www.ebi.ac.uk/efo/EFO_0000001">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An experimental factor in Array Express which are essentially the variable aspects of an experiment design which can be used to describe an experiment, or set of experiments, in an increasingly detailed manner. This upper level class is really used to give a root class from which applications can rely on and not be tied to upper ontology classses which do change.</obo:IAO_0000115>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Concept naming convention is lower case natural naming with spaces, when necessary captials should be used, for example disease factor, HIV, breast carcinoma, Ewing's sarcoma</rdfs:comment>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ExperimentalFactor</oboInOwl:hasExactSynonym>
-        <efo:bioportal_provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ExperimentalFactor[accessedResource: MO_10][accessDate: 05-04-2011]</efo:bioportal_provenance>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helen Parkinson</oboInOwl:created_by>
-        <efo:definition_editor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helen Parkinson</efo:definition_editor>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</oboInOwl:created_by>
-        <efo:definition_editor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</efo:definition_editor>
-        <efo:definition_editor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jie Zheng</efo:definition_editor>
-        <efo:definition_citation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MO_10</efo:definition_citation>
-        <efo:definition_editor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tomasz Adamusiak</efo:definition_editor>
-        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tomasz Adamusiak</oboInOwl:created_by>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tomasz Adamusiak</obo:IAO_0000117>
         <efo:organizational_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</efo:organizational_class>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helen Parkinson</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</oboInOwl:created_by>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tomasz Adamusiak</oboInOwl:created_by>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MO:10</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ExperimentalFactor</oboInOwl:hasExactSynonym>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Concept naming convention is lower case natural naming with spaces, when necessary captials should be used, for example disease factor, HIV, breast carcinoma, Ewing&apos;s sarcoma</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">experimental factor</rdfs:label>
     </owl:Class>
 	
-    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/snap#MaterialEntity">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material entity</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
         <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000001"/>
-        <efo:example_of_usage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A heart, a human, a fly, a microarray.</efo:example_of_usage>
-        <efo:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity is an entity that exists in full during the length of time of its existence, persists through this time while maintaining its identity and has no temporal parts. For example a heart, a human, a fly, a microarray.</efo:definition>
-        <efo:source_definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An independent continuant [snap:IndependentContinuant] that is spatially extended whose identity is independent of that of other entities and can be maintained through time. Note: Material entity [snap:MaterialEntity] subsumes object [snap:Object], fiat object part [snap:FiatObjectPart], and object aggregate [snap:ObjectAggregate], which assume a three level theory of granularity, which is inadequate for some domains, such as biology.</efo:source_definition>
-        <efo:definition_editor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</efo:definition_editor>
-        <efo:EFO_URI rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.ebi.ac.uk/efo/EFO_0001434</efo:EFO_URI>
-        <efo:ArrayExpress_label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample factor</efo:ArrayExpress_label>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An information entity is an entity that represents information about some other entity.  For example, a measurement, a clustered data set.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James Malone</obo:IAO_0000117>
+        <efo:ArrayExpress_label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">information</efo:ArrayExpress_label>
+        <efo:EFO_URI rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.ebi.ac.uk/efo/EFO_0001435</efo:EFO_URI>
         <efo:organizational_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</efo:organizational_class>
-        <efo:alternative_term>material type</efo:alternative_term>
+        <efo:source_definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an information content entity is an entity that is generically dependent on some artifact and stands in relation of aboutness to some entity</efo:source_definition>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">information content entity</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">information entity</rdfs:label>
     </owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION
I included two new settings in the configuration to skip child/descendant document references:
- `includeChildren`
- `includeDescendants`

They are `true` by default to match the behaviour in BioSolr’s earlier versions. The rationale to include these two settings can be seen in this example:
- https://gist.github.com/alfonsomunozpomer/d7ef72bef02fb8990cb8abd423cd6ca2
- https://gist.github.com/alfonsomunozpomer/5944e7aa271a34c53c7c62371fe98436

The size of the documents is drastically reduced and the child/descendants is something we don’t need in Expression Atlas.

I fixed some OLS tests that were failing because the expected terms were outdated. Since those tests are also shared with the OWL ones, I adjusted `test.owl` to match the latest EFO release so that it would match whatever OLS pulls from the API.